### PR TITLE
restore autoptr performance and reduce invalidations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoBZ"
 uuid = "00d1ae05-4f20-4598-b864-bbb2ed8900e6"
 authors = ["lxvm <lorenzo@vanmunoz.com> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AutoBZCore = "66bd3e16-1600-45cf-8f55-0b550710682b"


### PR DESCRIPTION
#24 fixed some things but broke others. This pr fixes the major issues I can find

Fixed by #24
* Making all parameters into keyword arguments fixed inconsistencies in how parameters were handled and made it possible for this pr to reduce invalidations
Broken by #24 
* Making all parameters into keyword arguments meant that the autoptr cache could potentially change on every new set of parameters, since the ptr step is computed from the self energy, and this wasn't handled correctly

This pr fixes:
* AutoPTR performance will be restored by making its cacheval mutable
* will reduce invalidations because it replaces piratical method definitions, e.g. `(::integrand)(x, ::CanonicalParameters)` with non-piratical calls
* Now users can always evaluate their integrand at a point, with a complete set of parameters, with `integrand(x, AutoBZCore.NullParameters())`
* Now CanonicalParameters is reserved for initializing a solver with an easy set of parameters. The users' parameters will only be applied at solve time

Eventually, we should implement IntegralSolver in terms of IntegralCache since a mutable cache will avoid the issues we had with AutoPTR. The only outstanding issue is how to deal with parameter transformations that change the types of parameters, since mutable will still have to be type-stable
