### PR TITLE
add droptol

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,22 @@ EquiBaryInterp = "c5458111-f826-47c0-abe9-f36aa00852ec"
 FourierSeriesEvaluators = "2a892dea-6eef-4bb5-9d1c-de966c9f6db5"
 HChebInterp = "78faba9b-a54b-441f-8118-62407cbe4e59"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[weakdeps]
+Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+WannierIO = "cb1bc77f-5443-4951-af9f-05b616a3e422"
+
+[extensions]
+AutoBZUnitfulExt = "Unitful"
+AutoBZWannierIOExt = "WannierIO"
+BrillouinMakieExt = ["Brillouin", "Makie"]
+BrillouinPlotlyJSExt = ["Brillouin", "PlotlyJS"]
 
 [compat]
 Aqua = "0.8"
@@ -20,23 +34,18 @@ BaryRational = "0.1,1"
 Brillouin = "0.5"
 EquiBaryInterp = "0.1"
 FourierSeriesEvaluators = "1"
-HChebInterp = "0.1,1"
+HChebInterp = "1"
 LinearAlgebra = "1.9"
+Logging = "1.9"
 Makie = "0.19"
 OffsetArrays = "1"
 PlotlyJS = "0.18"
 Reexport = "1"
 StaticArrays = "1"
-WannierIO = "0.2"
 Test = "1.9"
 Unitful = "1"
+WannierIO = "0.2"
 julia = "1.9"
-
-[extensions]
-AutoBZUnitfulExt = "Unitful"
-BrillouinMakieExt = ["Brillouin", "Makie"]
-BrillouinPlotlyJSExt = ["Brillouin", "PlotlyJS"]
-AutoBZWannierIOExt = "WannierIO"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -52,10 +61,3 @@ WannierIO = "cb1bc77f-5443-4951-af9f-05b616a3e422"
 
 [targets]
 test = ["Aqua", "AutoBZCore", "LinearAlgebra", "StaticArrays", "OffsetArrays", "Test"]
-
-[weakdeps]
-Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
-WannierIO = "cb1bc77f-5443-4951-af9f-05b616a3e422"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/src/AutoBZ.jl
+++ b/src/AutoBZ.jl
@@ -52,6 +52,7 @@ module AutoBZ
 
 using LinearAlgebra
 using LinearAlgebra: checksquare
+using Logging
 
 using StaticArrays
 using Reexport

--- a/src/interp.jl
+++ b/src/interp.jl
@@ -237,7 +237,7 @@ struct MassVelocityInterp{C,B,G,N,T,iip,F,DF,TA} <: AbstractVelocityInterp{C,B,G
     h::HessianSeries{N,T,iip,F,DF}
     A::TA
     function MassVelocityInterp{C,B,G}(h::HessianSeries{N,T,iip,F,DF}, A::TA) where {C,B,G,N,T,iip,F,DF,TA}
-        @assert gauge(parentseries(h)) == GaugeDefault(parentseries(h))
+        @assert gauge(_parentseries(h)) == GaugeDefault(_parentseries(h))
         return new{C,B,G,N,T,iip,F,DF,TA}(h, A)
     end
 end

--- a/src/self_energies_io.jl
+++ b/src/self_energies_io.jl
@@ -139,9 +139,5 @@ function construct_chebyshev(omegas, values::Vector{<:Number}, order; atol=1e-6,
 end
 function construct_chebyshev(omegas, values::Vector{T}, order; atol=1e-6, tol=1e-13, mmax=100) where {T<:SArray}
     interp = ntuple(n -> aaa(omegas, getindex.(values, n); tol=tol, mmax=mmax), length(T))
-    ndims(T) > 1 && @warn """
-    Matrix-valued interpolation may not work without the FastChebInterp version at
-    `import Pkg; Pkg.add(url="https://github.com/lxvm/FastChebInterp.jl.git#pr_sarray")`
-    """
     hchebinterp(x -> T(map(f -> f(x), interp)), extrema(omegas)...; order=order, atol=atol)
 end

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -54,13 +54,12 @@ keyword `compact` to specify:
 - `:U`: store the upper triangle of the coefficients
 - `:S`: store the lower triangle of the symmetrized coefficients, `(c+c')/2`
 """
-function load_interp(::Type{<:HamiltonianInterp}, seed; precision=Float64, gauge=GaugeDefault(HamiltonianInterp), compact=:N, soc=nothing)
+function load_interp(::Type{<:HamiltonianInterp}, seed; precision=Float64, gauge=GaugeDefault(HamiltonianInterp), compact=:N, soc=nothing, droptol=eps(precision))
     A, B, species, site, frac_lat, cart_lat, proj, kpts = parse_wout(seed * ".wout", precision)
     date_time, num_wann, nrpts, degen, irvec, C_ = parse_hamiltonian(seed * "_hr.dat", precision)
     check_degen(degen, kpts.nkpt)
-    C = load_coefficients(Val{compact}(), num_wann, irvec, degen, C_)[1]
-    offset = map(s -> -div(s,2)-1, size(C))
-    f = FourierSeries(C; period=freq2rad(one(precision)), offset=offset)
+    (C, origin), = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, C_)
+    f = FourierSeries(C; period=freq2rad(one(precision)), offset=Tuple(-origin))
     if soc === nothing
         return HamiltonianInterp(Freq2RadSeries(f), gauge=gauge)
     else
@@ -76,29 +75,59 @@ load_coeff(T, ::Val{:L}, c) = T(c)
 load_coeff(T, ::Val{:U}, c) = T(c')
 load_coeff(T, ::Val{:S}, c) = T(0.5*(c+c'))
 
-function load_coefficients(compact, num_wann, irvec, degen, cs...)
-    return load_coefficients(compact, num_wann, irvec, degen, cs)
+function load_coefficients(compact, droptol, num_wann, irvec, degen, cs...)
+    return load_coefficients(compact, droptol, num_wann, irvec, degen, cs)
 end
-function load_coefficients(compact, num_wann, irvec, degen, cs::NTuple{N}) where N
+function load_coefficients(compact, reltol, num_wann, irvec, degen, cs::NTuple{N}) where N
     T = load_coeff_type(eltype(eltype(eltype(cs))), compact, num_wann)
-    nmodes = zeros(Int, 3)
-    for idx in irvec
-        @inbounds for i in 1:3
-            if (n = abs(idx[i])) > nmodes[i]
-                nmodes[i] = n
-            end
-        end
-    end
-    Cs = ntuple(_ -> zeros(T, (2nmodes .+ 1)...), Val(N))
+    bounds = ntuple(n -> extrema(idx -> idx[n], irvec), Val(3))
+    lbounds = map(first, bounds)
+    ubounds = map(last,  bounds)
+    nmodes = map((lb, ub) -> ub-lb+1, lbounds, ubounds)
+    Cs = ntuple(_ -> zeros(T, nmodes), Val(N))
+    origins = map(C -> CartesianIndex(ntuple(n -> firstindex(C,n)-lbounds[n], Val(3))), Cs)
     for (i,idx) in enumerate(irvec)
-        idx_ = CartesianIndex((idx .+ nmodes .+ 1)...)
-        for (j,c) in enumerate(cs)
-            Cs[j][idx_] = load_coeff(T, compact, c[i])/degen[i]
+        _idx_ = CartesianIndex(idx...)
+        for (c,C,o) in zip(cs, Cs, origins)
+            C[_idx_+o] = load_coeff(T, compact, c[i])/degen[i]
         end
     end
-    return Cs
+    return map((C, origin) -> droptol(C, origin, reltol), Cs, origins)
 end
 
+infnorm(x::Number) = abs(x)
+infnorm(x::AbstractArray) = maximum(infnorm, x)
+
+# based on FastChebInterp.jl and helpful for truncating zero-padded coefficients
+function droptol(C::AbstractArray, origin::CartesianIndex, reltol)
+    abstol = infnorm(C) * reltol
+    norm_geq_tol = >=(abstol)∘infnorm
+    all(norm_geq_tol, C) && return (C, origin)
+
+    # compute the new size, dropping values below tol at both ends of axes
+    N = ndims(C)
+    newlb = ntuple(Val(N)) do dim
+        n = firstindex(C, dim)
+        while n < lastindex(C, dim)
+            r = ntuple(i -> axes(C,i)[i == dim ? (n:n) : (begin:end)], Val(N))
+            any(norm_geq_tol, @view C[CartesianIndices(r)]) && break
+            n += 1
+        end
+        n
+    end
+    newub = ntuple(Val(N)) do dim
+        n = lastindex(C, dim)
+        while n > firstindex(C, dim)
+            r = ntuple(i -> axes(C,i)[i == dim ? (n:n) : (begin:end)], Val(N))
+            any(norm_geq_tol, @view C[CartesianIndices(r)]) && break
+            n -= 1
+        end
+        n
+    end
+    newC = C[CartesianIndices(map(:, newlb, newub))]
+    neworigin = origin + CartesianIndex(ntuple(n -> firstindex(newC,n)-newlb[n], Val(N)))
+    return (newC, neworigin)
+end
 
 """
     parse_position_operator(filename, rot=I)
@@ -166,19 +195,19 @@ Fourier coefficients in compact form, use the keyword `compact` to specify:
 Note that in some cases the coefficients are not Hermitian even though the
 values of the series are.
 """
-function load_interp(::Type{<:BerryConnectionInterp}, seed; precision=Float64, coord=CoordDefault(BerryConnectionInterp), period=one(precision), compact=:N, soc=nothing)
+function load_interp(::Type{<:BerryConnectionInterp}, seed; precision=Float64, coord=CoordDefault(BerryConnectionInterp), period=one(precision), compact=:N, soc=nothing, droptol=eps(precision))
     A, B, species, site, frac_lat, cart_lat, proj, kpts = parse_wout(seed * ".wout", precision)
     invA = inv(A) # compute inv(A) for map from Cartesian to lattice coordinates
     rot, irot = pick_rot(coord, A, invA)
-    date_time, num_wann, nrpts, degen, irvec, C_ = parse_hamiltonian(seed * "_hr.dat", precision)
+    date_time, num_wann, nrpts, degen, irvec, = parse_hamiltonian(seed * "_hr.dat", precision)
     check_degen(degen, kpts.nkpt)
     date_time, num_wann, nrpts, irvec, A1_, A2_, A3_ = parse_position_operator(seed * "_r.dat", precision, rot)
-    A1, A2, A3 = load_coefficients(Val{compact}(), num_wann, irvec, degen, A1_, A2_, A3_)
-    F1_ = FourierSeries(A1; period=one(precision), offset=map(s -> -div(s,2)-1, size(A1)))
+    (A1,o1), (A2,o2), (A3,o3) = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, A1_, A2_, A3_)
+    F1_ = FourierSeries(A1; period=one(precision), offset=Tuple(-o1))
     F1  = soc === nothing ? F1_ : WrapperFourierSeries(wrap_soc, F1_)
-    F2_ = FourierSeries(A2; period=one(precision), offset=map(s -> -div(s,2)-1, size(A2)))
+    F2_ = FourierSeries(A2; period=one(precision), offset=Tuple(-o2))
     F2  = soc === nothing ? F2_ : WrapperFourierSeries(wrap_soc, F2_)
-    F3_ = FourierSeries(A3; period=one(precision), offset=map(s -> -div(s,2)-1, size(A3)))
+    F3_ = FourierSeries(A3; period=one(precision), offset=Tuple(-o3))
     F3  = soc === nothing ? F3_ : WrapperFourierSeries(wrap_soc, F3_)
     BerryConnectionInterp{coord}(ManyFourierSeries(F1, F2, F3; period=period), irot; coord=coord)
 end

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -415,6 +415,11 @@ function load_autobz(bz::IBZ, seedname::String; precision=Float64, kws...)
     return load_bz(convert(AbstractBZ{3}, bz), a, b, species, frac_lat; kws..., coordinates="lattice")
 end
 
+struct CompactDisplay{T}
+    obj::T
+end
+Base.show(io::IO, a::CompactDisplay) = show(io, a.obj)
+
 """
     load_wannier90_data(seedname::String; bz::AbstractBZ=FBZ(), interp::AbstractWannierInterp=HamiltonianInterp, kwargs...)
 
@@ -440,13 +445,10 @@ function load_wannier90_data(seedname::String; precision=Float64, load_interp=lo
             val = wi(S*k)
             return calc_interp_error(wi, val, ref)
         end
-        msg = """
-        Testing that the interpolant's Hamiltonian satisfies the symmetries at random k-point
-            k = $(k)
-        and found a maximum error $(err) for symmetry
-            bz.syms[$(idx)] = $(bz.syms[idx])
-        """
-        err > sqrt(eps(one(err)))*oneunit(err) ? @warn(msg) : @info(msg)
+        sym = CompactDisplay(bz.syms[idx])
+        kpt = CompactDisplay(k)
+        msg = "Symmetry test of the interpolant's Hamiltonian at a random k-point"
+        @logmsg (err > sqrt(eps(one(err)))*oneunit(err) ? Warn : Info) msg seedname kpt sym err
     end
     return (wi, bz)
 end

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -37,7 +37,7 @@ function parse_hamiltonian(file::IO, ::Type{F}) where {F<:AbstractFloat}
         end
         C[k] = SMatrix{num_wann,num_wann,Complex{F},num_wann^2}(c)
     end
-    return (; date_time, num_wann, nrpts, degen, irvec, C)
+    return (; date_time, num_wann, nrpts, degen, irvec, H=C)
 end
 
 """
@@ -56,9 +56,9 @@ keyword `compact` to specify:
 """
 function load_interp(::Type{<:HamiltonianInterp}, seed; precision=Float64, gauge=GaugeDefault(HamiltonianInterp), compact=:N, soc=nothing, droptol=eps(precision))
     (; nkpt) = parse_wout(seed * ".wout", precision)
-    (; num_wann, degen, irvec, C) = parse_hamiltonian(seed * "_hr.dat", precision)
+    (; num_wann, degen, irvec, H) = parse_hamiltonian(seed * "_hr.dat", precision)
     check_degen(degen, nkpt)
-    (C, origin), = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, C)
+    (C, origin), = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, H)
     f = FourierSeries(C; period=freq2rad(one(precision)), offset=Tuple(-origin))
     if soc === nothing
         return HamiltonianInterp(Freq2RadSeries(f), gauge=gauge)
@@ -202,14 +202,13 @@ function load_interp(::Type{<:BerryConnectionInterp}, seed; precision=Float64, c
     (; degen) = parse_hamiltonian(seed * "_hr.dat", precision)
     check_degen(degen, nkpt)
     (; num_wann, irvec, As) = parse_position_operator(seed * "_r.dat", precision, rot)
-    (A1,o1), (A2,o2), (A3,o3) = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, As...)
-    F1_ = FourierSeries(A1; period=one(precision), offset=Tuple(-o1))
-    F1  = soc === nothing ? F1_ : WrapperFourierSeries(wrap_soc, F1_)
-    F2_ = FourierSeries(A2; period=one(precision), offset=Tuple(-o2))
-    F2  = soc === nothing ? F2_ : WrapperFourierSeries(wrap_soc, F2_)
-    F3_ = FourierSeries(A3; period=one(precision), offset=Tuple(-o3))
-    F3  = soc === nothing ? F3_ : WrapperFourierSeries(wrap_soc, F3_)
-    BerryConnectionInterp{coord}(ManyFourierSeries(F1, F2, F3; period=period), irot; coord=coord)
+    (A1,o1), (A2,o2), (A3,o3) = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, As)
+    F1 = FourierSeries(A1; period=one(precision), offset=Tuple(-o1))
+    F2 = FourierSeries(A2; period=one(precision), offset=Tuple(-o2))
+    F3 = FourierSeries(A3; period=one(precision), offset=Tuple(-o3))
+    Fs = (F1, F2, F3)
+    Ms = soc === nothing ? Fs : map(f -> WrapperFourierSeries(wrap_soc, f), Fs)
+    BerryConnectionInterp{coord}(ManyFourierSeries(Ms...; period=period), irot; coord=coord)
 end
 
 """

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -377,6 +377,11 @@ function load_autobz(bz::IBZ, seedname::String; precision=Float64, kws...)
     return load_bz(convert(AbstractBZ{3}, bz), A, B, species, reduce(hcat, frac_lat); kws..., coordinates="lattice")
 end
 
+struct CompactDisplay{T}
+    obj::T
+end
+Base.show(io::IO, a::CompactDisplay) = show(io, a.obj)
+
 """
     load_wannier90_data(seedname::String; bz::AbstractBZ=FBZ(), interp::AbstractWannierInterp=HamiltonianInterp, kwargs...)
 
@@ -402,13 +407,10 @@ function load_wannier90_data(seedname::String; precision=Float64, load_interp=lo
             val = wi(S*k)
             return calc_interp_error(wi, val, ref)
         end
-        msg = """
-        Testing that the interpolant's Hamiltonian satisfies the symmetries at random k-point
-            k = $(k)
-        and found a maximum error $(err) for symmetry
-            bz.syms[$(idx)] = $(bz.syms[idx])
-        """
-        err > sqrt(eps(one(err)))*oneunit(err) ? @warn(msg) : @info(msg)
+        sym = CompactDisplay(bz.syms[idx])
+        kpt = CompactDisplay(k)
+        msg = "Symmetry test of the interpolant's Hamiltonian at a random k-point"
+        @logmsg (err > sqrt(eps(one(err)))*oneunit(err) ? Warn : Info) msg seedname kpt sym err
     end
     return (wi, bz)
 end

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -37,7 +37,7 @@ function parse_hamiltonian(file::IO, ::Type{F}) where {F<:AbstractFloat}
         end
         C[k] = SMatrix{num_wann,num_wann,Complex{F},num_wann^2}(c)
     end
-    return date_time, num_wann, nrpts, degen, irvec, C
+    return (; date_time, num_wann, nrpts, degen, irvec, C)
 end
 
 """
@@ -54,12 +54,13 @@ keyword `compact` to specify:
 - `:U`: store the upper triangle of the coefficients
 - `:S`: store the lower triangle of the symmetrized coefficients, `(c+c')/2`
 """
-function load_interp(::Type{<:HamiltonianInterp}, seed; precision=Float64, gauge=GaugeDefault(HamiltonianInterp), compact=:N, soc=nothing, droptol=eps(precision))
-    A, B, species, site, frac_lat, cart_lat, proj, kpts = parse_wout(seed * ".wout", precision)
-    date_time, num_wann, nrpts, degen, irvec, C_ = parse_hamiltonian(seed * "_hr.dat", precision)
-    check_degen(degen, kpts.nkpt)
-    (C, origin), = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, C_)
-    f = FourierSeries(C; period=freq2rad(one(precision)), offset=Tuple(-origin))
+function load_interp(::Type{<:HamiltonianInterp}, seed; precision=Float64, gauge=GaugeDefault(HamiltonianInterp), compact=:N, soc=nothing)
+    (; nkpt) = parse_wout(seed * ".wout", precision)
+    (; num_wann, degen, irvec, C) = parse_hamiltonian(seed * "_hr.dat", precision)
+    check_degen(degen, nkpt)
+    C_ = load_coefficients(Val{compact}(), num_wann, irvec, degen, C)[1]
+    offset = map(s -> -div(s,2)-1, size(C_))
+    f = FourierSeries(C_; period=freq2rad(one(precision)), offset=offset)
     if soc === nothing
         return HamiltonianInterp(Freq2RadSeries(f), gauge=gauge)
     else
@@ -173,7 +174,7 @@ function parse_position_operator(file::IO, ::Type{F}, rot=I) where {F<:AbstractF
         A2[k] = T(a2)
         A3[k] = T(a3)
     end
-    return date_time, num_wann, nrpts, irvec, A1, A2, A3
+    return (; date_time, num_wann, nrpts, irvec, As=(A1, A2, A3))
 end
 
 pick_rot(::Cartesian, A, invA) = (I, invA)
@@ -195,15 +196,15 @@ Fourier coefficients in compact form, use the keyword `compact` to specify:
 Note that in some cases the coefficients are not Hermitian even though the
 values of the series are.
 """
-function load_interp(::Type{<:BerryConnectionInterp}, seed; precision=Float64, coord=CoordDefault(BerryConnectionInterp), period=one(precision), compact=:N, soc=nothing, droptol=eps(precision))
-    A, B, species, site, frac_lat, cart_lat, proj, kpts = parse_wout(seed * ".wout", precision)
+function load_interp(::Type{<:BerryConnectionInterp}, seed; precision=Float64, coord=CoordDefault(BerryConnectionInterp), period=one(precision), compact=:N, soc=nothing)
+    (; A, nkpt) = parse_wout(seed * ".wout", precision)
     invA = inv(A) # compute inv(A) for map from Cartesian to lattice coordinates
     rot, irot = pick_rot(coord, A, invA)
-    date_time, num_wann, nrpts, degen, irvec, = parse_hamiltonian(seed * "_hr.dat", precision)
-    check_degen(degen, kpts.nkpt)
-    date_time, num_wann, nrpts, irvec, A1_, A2_, A3_ = parse_position_operator(seed * "_r.dat", precision, rot)
-    (A1,o1), (A2,o2), (A3,o3) = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, A1_, A2_, A3_)
-    F1_ = FourierSeries(A1; period=one(precision), offset=Tuple(-o1))
+    (; degen) = parse_hamiltonian(seed * "_hr.dat", precision)
+    check_degen(degen, nkpt)
+    (; num_wann, irvec, As) = parse_position_operator(seed * "_r.dat", precision, rot)
+    A1, A2, A3 = load_coefficients(Val{compact}(), num_wann, irvec, degen, As...)
+    F1_ = FourierSeries(A1; period=one(precision), offset=map(s -> -div(s,2)-1, size(A1)))
     F1  = soc === nothing ? F1_ : WrapperFourierSeries(wrap_soc, F1_)
     F2_ = FourierSeries(A2; period=one(precision), offset=Tuple(-o2))
     F2  = soc === nothing ? F2_ : WrapperFourierSeries(wrap_soc, F2_)
@@ -258,6 +259,11 @@ function load_interp(::Type{<:MassVelocityInterp}, seed, A;
     return MassVelocityInterp(h, A; coord=coord, vcomp=vcomp, gauge=gauge)
 end
 
+function _split!(c, s, args...; kws...)
+    empty!(c)
+    append!(c, eachsplit(s, args...; kws...))
+end
+
 """
     parse_wout(filename; iprint=1)
 
@@ -265,118 +271,75 @@ returns the lattice vectors `a` and reciprocal lattice vectors `b`
 """
 function parse_wout(file::IO, ::Type{F}) where {F<:AbstractFloat}
 
-    # header
-    while (l = strip(readline(file))) != "SYSTEM"
-        continue
-    end
+    cols = SubString{String}[]
+    c = zero(MMatrix{3,3,F,9})
+    A = SMatrix(c)
+    vol = zero(F)
+    B = SMatrix(c)
 
-    # system
-    readline(file)
-    readline(file)
-    readline(file)
-    ## lattice vectors
-    c = Matrix{F}(undef, 3, 3)
-    for i in 1:3
-        col = split(readline(file))
-        popfirst!(col)
-        @. c[:,i] = parse(F, col)
-    end
-    A = SMatrix{3,3,F,9}(c)
-
-    readline(file)
-    readline(file)
-    readline(file)
-    readline(file)
-    ## reciprocal lattice vectors
-    for i in 1:3
-        col = split(readline(file))
-        popfirst!(col)
-        @. c[:,i] = parse(F, col)
-    end
-    B = SMatrix{3,3,F,9}(c)
-
-
-    readline(file)
-    readline(file)
-    readline(file) # site fractional coordinate cartesian coordinate (unit)
-    readline(file)
-    # lattice
     species = String[]
     site = Int[]
-    frac_lat_ = SVector{3,F}[]
-    cart_lat_ = SVector{3,F}[]
-    while true
-        col = split(readline(file))
-        length(col) == 11 || break
-        push!(species, col[2])
-        push!(site, parse(Int, col[3]))
-        push!(frac_lat_, parse.(F, col[4:6]))
-        push!(cart_lat_, parse.(F, col[8:10]))
+    frac_lat = SVector{3,F}[]
+    cart_lat = SVector{3,F}[]
+
+    nk1 = nk2 = nk3 = nkpt = 0
+
+    # skip header
+    while !eof(file)
+        line = readline(file)
+        if occursin("Lattice Vectors", line)
+            occursin("Ang", line) || @warn "Length unit other than Angstrom detected"
+            _split!(cols, line)
+            for i in 1:3
+                line = readline(file)
+                _split!(cols, line)
+                @assert popfirst!(cols) == "a_$i"
+                @. c[:,i] = parse(F, cols)
+            end
+            A = SMatrix(c)
+            continue
+        end
+
+        if occursin("Unit Cell Volume:", line)
+            _split!(cols, line)
+            vol = parse(F, cols[4])
+            continue
+        end
+
+        if occursin("Reciprocal-Space Vectors", line)
+            for i in 1:3
+                line = readline(file)
+                _split!(cols, line)
+                @assert popfirst!(cols) == "b_$i"
+                @. c[:,i] = parse(F, cols)
+            end
+            B = SMatrix(c)
+            continue
+        end
+
+        if occursin("Site", line)
+            readline(file)
+            while true
+                line = readline(file)
+                _split!(cols, line)
+                length(cols) == 11 || break
+                push!(species, cols[2])
+                push!(site, parse(Int, cols[3]))
+                push!(frac_lat, parse.(F, cols[4:6]))
+                push!(cart_lat, parse.(F, cols[8:10]))
+            end
+            continue
+        end
+
+        if occursin("Grid size", line)
+            _split!(cols, line)
+            nk1 = parse(Int, cols[4])
+            nk2 = parse(Int, cols[6])
+            nk3 = parse(Int, cols[8])
+            nkpt = parse(Int, cols[12])
+        end
     end
-    frac_lat = Matrix(reshape(reinterpret(F, frac_lat_), 3, :))
-    cart_lat = Matrix(reshape(reinterpret(F, cart_lat_), 3, :))
-
-    readline(file)
-    readline(file) # projections
-    readline(file)
-    readline(file)
-    readline(file)
-    readline(file) # Frac. coord, l, mr, r, z-axis, x-axis, Z/a
-    readline(file)
-
-    pfrac = SVector{3,F}[]
-    l = Int[]
-    mr = Int[]
-    r = Int[]
-    zax = SVector{3,F}[]
-    xax = SVector{3,F}[]
-    za = F[]
-    while true
-        col = split(readline(file))
-        length(col) == 15 || break
-        push!(pfrac, SVector{3,F}(parse.(F, col[2:4])))
-        push!(l, parse(Int, col[5]))
-        push!(mr, parse(Int, col[6]))
-        push!(r, parse(Int, col[7]))
-        push!(zax, SVector{3,F}(parse.(F, col[8:10])))
-        push!(xax, SVector{3,F}(parse.(F, col[11:13])))
-        push!(za, parse(F, col[14]))
-    end
-    proj = (; frac=pfrac, l=l, mr=mr, r=r, zax=zax, xax=xax, za=za)
-
-    # k-point grid
-    readline(file)
-    readline(file)
-    readline(file) # k-point grid
-    readline(file)
-    readline(file)
-
-    kpt_header = split(readline(file))
-    sizes = (parse(Int, kpt_header[4]), parse(Int, kpt_header[6]), parse(Int, kpt_header[8]))
-    nkpt = parse(Int, kpt_header[12])
-    readline(file)
-    readline(file)
-    readline(file)  # k-point, fractional coordinate, Cartesian coordinate (Ang^-1)
-    readline(file)
-    ikvec = Vector{Int}(undef, nkpt)
-    kfrac = Vector{SVector{3,F}}(undef, nkpt)
-    kcart = Vector{SVector{3,F}}(undef, nkpt)
-    for i in 1:nkpt
-        col = split(readline(file))
-        ikvec[i] = parse(Int, col[2])
-        kfrac[i] = parse.(F, col[3:5])
-        kcart[i] = parse.(F, col[7:9])
-    end
-    kpts = (; sizes=sizes, nkpt=nkpt, ikvec=ikvec, cart=kcart, frac=kfrac)
-
-    # main
-    # wannierise
-    # disentangle
-    # plotting
-    # k-mesh
-    # etc...
-
-    return A, B, species, site, frac_lat, cart_lat, proj, kpts
+    return (; A, B, vol, species, site, frac_lat, cart_lat, nkpt, dims=(nk1,nk2,nk3))
 end
 
 function parse_sym(file::IO, ::Type{F}) where {F<:AbstractFloat}
@@ -394,7 +357,7 @@ function parse_sym(file::IO, ::Type{F}) where {F<:AbstractFloat}
         translate[i] = S[:,4]
         readline(file)
     end
-    return nsymmetry, point_sym, translate
+    return (; nsymmetry, point_sym, translate)
 end
 
 load_interp(seedname::String; kwargs...) =
@@ -407,12 +370,12 @@ Automatically load a BZ using data from a "seedname.wout" file with the `load_bz
 from AutoBZCore.
 """
 function load_autobz(bz::AbstractBZ, seedname::String; precision=Float64, atol=1e-5)
-    A, B, = parse_wout(seedname * ".wout", precision)
+    (; A, B) = parse_wout(seedname * ".wout", precision)
     return load_bz(bz, A, B; atol=atol)
 end
 function load_autobz(bz::IBZ, seedname::String; precision=Float64, kws...)
-    a, b, species, site, frac_lat, cart_lat = parse_wout(seedname * ".wout", precision)
-    return load_bz(convert(AbstractBZ{3}, bz), a, b, species, frac_lat; kws..., coordinates="lattice")
+    (; A, B, species, frac_lat) = parse_wout(seedname * ".wout", precision)
+    return load_bz(convert(AbstractBZ{3}, bz), A, B, species, reduce(hcat, frac_lat); kws..., coordinates="lattice")
 end
 
 struct CompactDisplay{T}

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -201,7 +201,7 @@ function load_interp(::Type{<:BerryConnectionInterp}, seed; precision=Float64, c
     rot, irot = pick_rot(coord, A, invA)
     (; degen) = parse_hamiltonian(seed * "_hr.dat", precision)
     check_degen(degen, nkpt)
-    (; num_wann, degen, As) = parse_position_operator(seed * "_r.dat", precision, rot)
+    (; num_wann, irvec, As) = parse_position_operator(seed * "_r.dat", precision, rot)
     (A1,o1), (A2,o2), (A3,o3) = load_coefficients(Val{compact}(), droptol, num_wann, irvec, degen, As...)
     F1_ = FourierSeries(A1; period=one(precision), offset=Tuple(-o1))
     F1  = soc === nothing ? F1_ : WrapperFourierSeries(wrap_soc, F1_)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -30,3 +30,37 @@ using Test, AutoBZ, OffsetArrays
     end
 
 end
+
+@testset "droptol" begin
+
+    Cpad = [
+        0.0 0.0 0.0 0.0
+        0.0 0.1 0.0 0.0
+        0.2 0.4 0.2 0.0
+        0.3 0.5 0.3 0.0
+        0.2 0.4 0.2 0.0
+        0.0 0.1 0.0 0.0
+    ]
+    OCpad = OffsetMatrix(Array(Cpad), -3:2, -1:2)
+    C = Cpad[begin+1:end, begin:end-1]
+    OC = OffsetMatrix(C, -2:2, -1:1)
+
+    @test @inferred(AutoBZ.droptol(Cpad,  CartesianIndex(4,2), eps())) == (C, CartesianIndex(3,2))
+    @test @inferred(AutoBZ.droptol(OCpad, CartesianIndex(0,0), eps())) == (C, CartesianIndex(3,2))
+    @test @inferred(AutoBZ.droptol(C,  CartesianIndex(3,2), eps())) == (C, CartesianIndex(3,2))
+    @test @inferred(AutoBZ.droptol(OC, CartesianIndex(0,0), eps())) == (C, CartesianIndex(3,2))
+
+
+    Cpad2 = [
+        0.0 0.0 0.0 0.0
+        0.0 0.0 0.0 0.0
+        0.0 0.1 0.0 0.0
+        0.2 0.4 0.2 0.0
+        0.3 0.5 0.3 0.0
+        0.2 0.4 0.2 0.0
+        0.0 0.1 0.0 0.0
+    ]
+    OCpad2 = OffsetMatrix(Array(Cpad2), -4:2, -1:2)
+    @test @inferred(AutoBZ.droptol(Cpad2,  CartesianIndex(5,2), eps())) == (C, CartesianIndex(3,2))
+    @test @inferred(AutoBZ.droptol(OCpad2, CartesianIndex(0,0), eps())) == (C, CartesianIndex(3,2))
+end


### PR DESCRIPTION
This pr makes updates to how wannier90 data is loaded, including:
* parsing the wout file in more cases, in the style of WannierIO.jl
* dropping Fourier coefficients below a certain threshold (default: machine precision)
* prettier printing of symmetry testing
We also drop support for an old version of HChebInterp that would emit warnings about interpolation of arrays.