### PR TITLE
v0.5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoBZ"
 uuid = "00d1ae05-4f20-4598-b864-bbb2ed8900e6"
 authors = ["lxvm <lorenzo@vanmunoz.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AutoBZCore = "66bd3e16-1600-45cf-8f55-0b550710682b"

--- a/demos/chem_pot_test.jl
+++ b/demos/chem_pot_test.jl
@@ -35,12 +35,14 @@ falg = QuadGKJL()
 for kalg in kalgs
     @show nameof(typeof(kalg))
     solver = ElectronDensitySolver(h, bz, kalg, Σ, falg; β, μ, abstol=atol, reltol=rtol)
-    @time @show solve!(solver).value
+    @time sol = solve!(solver)
+    @show sol.value sol.stats
 end
 
 # loop to test various routines with the frequency integral on the outside
 for kalg in kalgs
     @show nameof(typeof(kalg))
     solver = ElectronDensitySolver(Σ, falg, h, bz, kalg; β, μ, abstol=atol, reltol=rtol)
-    @time @show solve!(solver).value
+    @time sol = solve!(solver)
+    @show sol.value sol.stats
 end

--- a/demos/dos_interp.jl
+++ b/demos/dos_interp.jl
@@ -33,7 +33,7 @@ fast_order = 15
 solver = DOSSolver(Σ, h, bz, IAI(); ω = (ω_lo+ω_hi)/2, abstol=atol, reltol=rtol)
 DOS = let solver=solver
     ω -> begin
-        AutoBZ.update_gloc!(solver; ω)
+        AutoBZ.update_dos!(solver; ω)
         solve!(solver).value
     end
 end

--- a/demos/dos_test.jl
+++ b/demos/dos_test.jl
@@ -30,6 +30,5 @@ for alg in algs
     @show nameof(typeof(alg))
     solver = DOSSolver(Σ, h, bz, alg; ω, abstol=atol, reltol=rtol)
     sol = @time solve!(solver)
-    @show sol.value
-    println()
+    @show sol.value sol.stats
 end

--- a/demos/oc_test.jl
+++ b/demos/oc_test.jl
@@ -36,12 +36,14 @@ kalgs = (IAI(), TAI(), PTR(; npt=npt), AutoPTR()) # BZ algorithms
 for kalg in kalgs
     @show nameof(typeof(kalg))
     solver = OpticalConductivitySolver(hv, bz, kalg, Σ, falg; Ω, β, abstol=atol, reltol=rtol)
-    @time @show solve!(solver).value
+    @time sol = solve!(solver)
+    @show sol.value sol.stats
 end
 
 # loop to test various routines with the frequency integral on the outside
 for kalg in kalgs
     @show nameof(typeof(kalg))
     solver = OpticalConductivitySolver(Σ, falg, hv, bz, kalg; Ω, β, abstol=atol, reltol=rtol)
-    @time @show solve!(solver).value
+    @time sol = solve!(solver)
+    @show sol.value sol.stats
 end

--- a/docs/src/pages/demo/density.md
+++ b/docs/src/pages/demo/density.md
@@ -41,7 +41,8 @@ bz = load_bz(CubicSymIBZ(), Diagonal(collect(AutoBZ.period(H))))
 Σ = EtaSelfEnergy(η)
 atol=1e-3
 rtol=0.0
-solver = ElectronDensitySolver(H, bz, PTR(npt=50), Σ, (-Inf, Inf), QuadGKJL(); β, abstol=atol/nsyms(bz), reltol=rtol)
+solver = ElectronDensitySolver(H, bz, PTR(npt=50), Σ, (-Inf, Inf), QuadGKJL(); β, abstol=atol/nsyms(bz), reltol=rtol);
+nothing # hide
 ```
 Here, we have chosen to the order of integration to compute a frequency integral
 for each ``\bm{k}`` point. We can compute the density over a range of chemical

--- a/docs/src/pages/demo/density.md
+++ b/docs/src/pages/demo/density.md
@@ -3,7 +3,13 @@
 The [electron density](https://en.wikipedia.org/wiki/Electron_density) describes
 the number of electrons in a system. It can be calculated by integrating the DOS
 times a Fermi distribution over all frequencies. Often calculations of the
-density are needed to ensure charge self-consistency.
+density are needed to ensure charge self-consistency. After walking through
+these tutorials, continue with the
+[`demos/chem_pot_test.jl`](https://github.com/lxvm/AutoBZ.jl/blob/main/demos/chem_pot_test.jl)
+script that compares several algorithms for the calculation of the electron
+density of a Wannier90 Hamiltonian using the [`load_wannier90_data`](@ref)
+interface and a frequency-dependent self energy using the
+[`load_self_energy`](@ref) interface.
 
 ## Model calculation
 

--- a/docs/src/pages/demo/dos.md
+++ b/docs/src/pages/demo/dos.md
@@ -57,8 +57,9 @@ integral
 ```
 where ``\omega`` is a frequency variable, ``\bm{k}`` is the reciprocal space
 vector, ``\mu`` is the chemical potential and ``\eta`` is a constant scattering
-rate. We implement our own user-defined integrand with the
-`AutoBZCore.FourierIntegralFunction`:
+rate. For pedagogical purposes, we implement our own integrand with the
+`AutoBZCore.FourierIntegralFunction`, although in the next example we show an
+equivalent calculation using a built-in [`DOSSolver`](@ref)
 ```@example dos_z
 ω = t*n # frequency at the band edge/Van-Hove singularity
 ħ = 1.0 # reduced Planck's constant

--- a/docs/src/pages/demo/dos.md
+++ b/docs/src/pages/demo/dos.md
@@ -3,7 +3,11 @@
 The [density of states (DOS)](https://en.wikipedia.org/wiki/Density_of_states)
 is a standard electronic structure calculation. Here we show how to calculate it
 using a finite scattering rate, i.e. at finite temperature, using AutoBZ.jl by
-working through a few examples.
+working through a few examples. After walking through these tutorials, continue
+with the
+[`demos/dos_test.jl`](https://github.com/lxvm/AutoBZ.jl/blob/main/demos/dos_test.jl)
+script that compares several algorithms for the calculation of the DOS of a
+Wannier90 Hamiltonian using the [`load_wannier90_data`](@ref) interface.
 
 ## DOS of the integer lattice tight-binding model
 
@@ -86,9 +90,6 @@ savefig("dos_z.png"); nothing # hide
 
 ![dos integer lattice](dos_z.png)
 
-
-You will find a working example of this model in the `DOS_example.jl` demo that
-computes DOS over a range of frequencies for this model.
 
 ## DOS interpolation for Graphene
 

--- a/docs/src/pages/demo/dos.md
+++ b/docs/src/pages/demo/dos.md
@@ -63,8 +63,8 @@ rate. We implement our own user-defined integrand with the
 ω = t*n # frequency at the band edge/Van-Hove singularity
 ħ = 1.0 # reduced Planck's constant
 η = 0.1 # broadening
-dos_integrand(k, H_k, (; η, ω)) = -imag(inv(ħ*ω - H_k + im*η))/pi # integrand evaluator
-D = FourierIntegralFunction(dos_integrand, H, (; η, ω)) # user-defined integrand with partial arguments
+dos_integrand(k, H_k, (; η, ω)) = -imag(inv(ħ*ω - H_k + im*η))/pi
+D = FourierIntegralFunction(dos_integrand, H)
 ```
 To compute the integral, we also need to provide the limits of integration, to
 specify an error tolerance, and to call one of the integration routines
@@ -174,7 +174,7 @@ interpolant for the DOS using
 ENV["GKSwstype"] = "100" # hide
 using HChebInterp
 using Plots
-DOS = hchebinterp(ω -> (AutoBZ.update_gloc!(solver; ω); solve!(solver).value), -ω, ω; atol=1e-3)
+DOS = hchebinterp(ω -> (AutoBZ.update_dos!(solver; ω); solve!(solver).value), -ω, ω; atol=1e-3)
 plot(range(-ω, ω, length=1000), DOS, title="Graphene", xguide="ħω", yguide="DOS", label="η=$η")
 savefig("dos_g.png"); nothing # hide
 ```

--- a/docs/src/pages/demo/dos.md
+++ b/docs/src/pages/demo/dos.md
@@ -71,7 +71,8 @@ specify an error tolerance, and to call one of the integration routines
 ```@example dos_z
 using LinearAlgebra
 bz = load_bz(CubicSymIBZ(), Diagonal(collect(AutoBZ.period(H)))) # Irreducible BZ for cubic symmetries is tetrahedron
-solver = init(AutoBZProblem(TrivialRep(), D, bz, (; η, ω)), PTR(npt=50))
+solver = init(AutoBZProblem(TrivialRep(), D, bz, (; η, ω)), PTR(npt=50));
+nothing # hide
 ```
 We can calculate and plot the DOS as a function of frequency
 ```@example dos_z
@@ -165,7 +166,8 @@ using LinearAlgebra
 η = 0.1 # eV
 Σ = EtaSelfEnergy(η)
 bz = load_bz(FBZ(2), Diagonal(collect(AutoBZ.period(H))))
-solver = DOSSolver(Σ, HamiltonianInterp(AutoBZ.Freq2RadSeries(H)), bz, PTR(npt=100); ω)
+solver = DOSSolver(Σ, HamiltonianInterp(AutoBZ.Freq2RadSeries(H)), bz, PTR(npt=100); ω);
+nothing # hide
 ```
 Using this integral solver, we can compute a fast-to-evaluate, adaptive
 interpolant for the DOS using

--- a/docs/src/pages/demo/oc.md
+++ b/docs/src/pages/demo/oc.md
@@ -4,7 +4,10 @@ The [optical conductivity](https://en.wikipedia.org/wiki/Optical_conductivity)
 is a response function that describes the electrical current response of a
 material to an incident electromagnetic field. AutoBZ.jl currently implements
 the longitudinal conductivity, which is the symmetric part of the conductivity
-tensor.
+tensor. After walking through these tutorials, continue with the
+[`demos/oc_test.jl`](https://github.com/lxvm/AutoBZ.jl/blob/main/demos/oc_test.jl)
+script that compares several algorithms for the calculation of the conductivity
+of a Wannier90 Hamiltonian using the [`load_wannier90_data`](@ref) interface.
 
 ## Model conductivity
 

--- a/docs/src/pages/demo/oc.md
+++ b/docs/src/pages/demo/oc.md
@@ -78,7 +78,7 @@ temperature
 ```@example oc
 temps = range(100, 300, length=10)
 f = T -> begin
-    AutoBZ.update_oc!(solver; β=inv(8.617333262e-5*T), Ω=0.0, μ, n=0)
+    AutoBZ.update_kc!(solver; β=inv(8.617333262e-5*T), Ω=0.0, μ, n=0)
     kc_0 = solve!(solver).value
     AutoBZ.update_kc!(solver; β=inv(8.617333262e-5*T), Ω=0.0, μ, n=1)
     kc_1 = solve!(solver).value

--- a/docs/src/pages/demo/oc.md
+++ b/docs/src/pages/demo/oc.md
@@ -66,15 +66,20 @@ savefig("conductivity.png"); nothing # hide
 
 A generalization of the optical conductivity is the
 [`AutoBZ.KineticCoefficientSolver`](@ref), which enables the calculation of
-additional transport properties. For example, we can compute the Seebeck
-coefficient as a function of temperature
+additional transport properties. In fact, and
+[`AutoBZ.OpticalConductivitySolver`](@ref) is implemented as a
+[`AutoBZ.KineticCoefficientSolver`](@ref) and so we can use them interchangeably.
+For example, we can compute the [Seebeck
+coefficient](https://en.wikipedia.org/wiki/Seebeck_coefficient) as a function of
+temperature
 ```@example oc
-solver_1 = KineticCoefficientSolver(hv, bz, PTR(npt=50), Σ, QuadGKJL(); n=1, Ω=0.0, β, μ, abstol=atol/nsyms(bz), reltol=rtol)
 temps = range(100, 300, length=10)
 f = T -> begin
-    AutoBZ.update_oc!(solver; β=inv(8.617333262e-5*T), Ω=0.0, μ)
-    AutoBZ.update_kc!(solver_1; β=inv(8.617333262e-5*T), Ω=0.0, μ, n=1)
-    -real(solve!(solver_1).value[1,1]) / real(solve!(solver).value[1,1])
+    AutoBZ.update_oc!(solver; β=inv(8.617333262e-5*T), Ω=0.0, μ, n=0)
+    kc_0 = solve!(solver).value
+    AutoBZ.update_kc!(solver; β=inv(8.617333262e-5*T), Ω=0.0, μ, n=1)
+    kc_1 = solve!(solver).value
+    -real(kc_1[1,1]) / real(kc_0[1,1])
 end
 plot(temps, f, title="Two hopping model", xguide="T", yguide="κₓₓ (a.u.)", label="η=$η")
 savefig("seebeck.png"); nothing # hide

--- a/docs/src/pages/demo/oc.md
+++ b/docs/src/pages/demo/oc.md
@@ -46,7 +46,8 @@ the BZ integral
 Σ = EtaSelfEnergy(η)
 atol=1e-3
 rtol=0.0
-solver = OpticalConductivitySolver(hv, bz, PTR(npt=50), Σ, QuadGKJL(); β, Ω=0.0, μ, abstol=atol/nsyms(bz), reltol=rtol)
+solver = OpticalConductivitySolver(hv, bz, PTR(npt=50), Σ, QuadGKJL(); β, Ω=0.0, μ, abstol=atol/nsyms(bz), reltol=rtol);
+nothing # hide
 ```
 Then we can evaluate the frequency dependence of the conductivity and plot
 particular matrix elements.

--- a/src/ElectronDensitySolver.jl
+++ b/src/ElectronDensitySolver.jl
@@ -8,7 +8,7 @@ function _DynamicalOccupiedGreensSolver(fun::F, Σ::AbstractSelfEnergy, fdom, fa
     # WARN: Σ evaluation in update_greens! may not be threadsafe so need another prob type
     up = (solver, ω, (_, (; β, μ))) -> (update_greens!(solver; ω, μ); return)
     post = (sol, ω, (_, (; β, μ))) -> sol.value*fermi(β, ω)
-    f = CommonSolveIntegralFunction(dos_prob, bzalg, up, post, proto)
+    f = CommonSolveIntegralFunction(dos_prob, _heuristic_bzalg(bzalg, Σ, h), up, post, proto)
     prob = IntegralProblem(f, get_safe_fermi_function_limits(β, fdom...), (fdom, p); kws...)
     return init(prob, falg)
 end
@@ -76,7 +76,7 @@ function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz
     post = (sol, k, h, p) -> sol.value
     g = CommonSolveFourierIntegralFunction(fprob, falg, up, post, h, proto*μ)
     prob = AutoBZProblem(rep, g, bz, p; kws...)
-    return init(prob, bzalg)
+    return init(prob, _heuristic_bzalg(bzalg, Σ, h))
 end
 
 function update_density!(solver::AutoBZCore.AutoBZCache; β, μ=zero(inv(oneunit(β))))

--- a/src/ElectronDensitySolver.jl
+++ b/src/ElectronDensitySolver.jl
@@ -22,7 +22,7 @@ function update_density!(solver::AutoBZCore.IntegralSolver; β, μ=zero(inv(oneu
     fdom = solver.p[1]
     if β != solver.p[2].β
         solver.dom = get_safe_fermi_function_limits(β, fdom...)
-        # TODO rescale inner tolerance based on domain length
+        # TODO rethink if inner tolerance needs to be rescaled if changing mu changes bandwidth
     end
     solver.p = (fdom, (; β, μ))
     return
@@ -68,7 +68,7 @@ function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz
         _fdom, _Σ, = solver.p
         if solver.p[4].β != p.β
             solver.dom = get_safe_fermi_function_limits(p.β, _fdom...)
-            # TODO rescale inner tolerance based on domain length
+            # TODO rethink if inner tolerance needs to be rescaled if changing mu changes bandwidth
         end
         solver.p = (_fdom, _Σ, h, p)
         return

--- a/src/GreensSolver.jl
+++ b/src/GreensSolver.jl
@@ -40,7 +40,7 @@ function _GreensProblem(fun::F, Σ::AbstractSelfEnergy, h::AbstractHamiltonianIn
 end
 function _GreensSolver(fun::F, Σ, h, bz, bzalg, linalg; kws...) where {F}
     prob = _GreensProblem(fun, Σ, h, bz, linalg; kws...)
-    return init(prob, bzalg)
+    return init(prob, _heuristic_bzalg(bzalg, Σ, h))
 end
 
 """

--- a/src/KineticCoefficientSolver.jl
+++ b/src/KineticCoefficientSolver.jl
@@ -5,7 +5,7 @@ function _DynamicalTransportDistributionSolver(fun::F, Σ::AbstractSelfEnergy, f
     post = (sol, ω, (_, (; β, μ, Ω, n))) -> (ω*β)^n * fermi_window(β, ω, Ω) * sol.value
     td_prob = _TransportDistributionProblem(fun, Σ, hv, bz, linalg; ω₁=zero(Ω), ω₂=Ω, μ, inner_kws...)
     proto = (float(zero(Ω))*β)^n * fermi_window(β, float(zero(Ω)), Ω) * td_prob.f.prototype
-    f = CommonSolveIntegralFunction(td_prob, bzalg, up, post, proto)
+    f = CommonSolveIntegralFunction(td_prob, _heuristic_bzalg(bzalg, Σ, hv), up, post, proto)
     prob = IntegralProblem(f, get_safe_fermi_window_limits(Ω, β, fdom...), (fdom, p); kws...)
     return init(prob, falg)
 end
@@ -58,7 +58,7 @@ function _DynamicalTransportDistributionSolver(fun::F, hv::AbstractVelocityInter
     post = (sol, k, h, p) -> sol.value
     f = CommonSolveFourierIntegralFunction(fprob, falg, up, post, hv, proto*Ω)
     prob = AutoBZProblem(coord_to_rep(coord(hv)), f, bz, p; kws...)
-    return init(prob, bzalg)
+    return init(prob, _heuristic_bzalg(bzalg, Σ, hv))
 end
 
 function update_kc!(solver::AutoBZCore.AutoBZCache; β, Ω, n, μ=zero(Ω))

--- a/src/KineticCoefficientSolver.jl
+++ b/src/KineticCoefficientSolver.jl
@@ -47,12 +47,12 @@ function _DynamicalTransportDistributionSolver(fun::F, hv::AbstractVelocityInter
         #     # function, and also this prevents (0*β)^n from giving NaN when n!=0
         #     return Ω * f.f(Ω, MixedParameters(; Σ, n, β=4*oneunit(β), Ω, μ, hv_k))
         # end
-        fdom, Σ, = solver.p
+        _fdom, _Σ, = solver.p
         if solver.p[4].Ω != p.Ω || solver.p[4].β != p.β
-            solver.dom = get_safe_fermi_window_limits(p.Ω, p.β, fdom...)
+            solver.dom = get_safe_fermi_window_limits(p.Ω, p.β, _fdom...)
             # TODO rescale inner tolerance based on domain length
         end
-        solver.p = (fdom, Σ, hv, p)
+        solver.p = (_fdom, _Σ, hv, p)
         return
     end
     post = (sol, k, h, p) -> sol.value

--- a/src/TransportDistributionSolver.jl
+++ b/src/TransportDistributionSolver.jl
@@ -148,7 +148,7 @@ Use `AutoBZ.update_td!(solver; ω₁, ω₂, μ=0)` to update the parameters.
 """
 function TransportDistributionSolver(Σ, hv, bz, bzalg, linalg=JLInv(); kws...)
     prob = _TransportDistributionProblem((Γ,_...) -> Γ, Σ, hv, bz, linalg; kws...)
-    return init(prob, bzalg)
+    return init(prob, _heuristic_bzalg(bzalg, Σ, hv))
 end
 
 """
@@ -164,7 +164,7 @@ Use `AutoBZ.update_auxtd!(solver; ω₁, ω₂, μ)` to update the parameters.
 """
 function AuxTransportDistributionSolver(auxfun::F, Σ::AbstractSelfEnergy, hv::AbstractVelocityInterp, bz, bzalg, linalg=JLInv(); kws...) where {F}
     prob = _TransportDistributionProblem((Γ, h, v, sol) -> AutoBZCore.IteratedIntegration.AuxValue(Γ, auxfun(v, sol.G1, sol.G2)), Σ, hv, bz, linalg; kws...)
-    return init(prob, bzalg)
+    return init(prob, _heuristic_bzalg(bzalg, Σ, hv))
 end
 AuxTransportDistributionSolver(Σ::AbstractSelfEnergy, hv::AbstractVelocityInterp, bz, bzalg, linalg=JLInv(); kws...) = AuxTransportDistributionSolver(_trG_auxfun, Σ, hv, bz, bzalg, linalg; _trG_kws(; kws...)...)
 _trG_auxfun(vs, Gω₁, Gω₂) = tr(Gω₁) + tr(Gω₂)

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -433,7 +433,8 @@ end
 function calc_interp_error(hv::AbstractVelocityInterp, val, err)
     # TODO test the symmetry on the velocity with a trace over the orbital indices, rotation
     # on coordinate indices
-    return calc_interp_error_(gauge(hv), val[1], err[1])
+    h = parentseries(hv)
+    return calc_interp_error_(init(h.prob, h.alg), gauge(hv), val[1], err[1])
 end
 calc_interp_error(::BerryConnectionInterp, val, err) = NaN
 


### PR DESCRIPTION
This patch restores a few features from v0.4. In all, it does:
- fix a misleading point in the docs and make some other improvements
- fix performance of captured variables in `KineticCoefficientSolver`s and `ElectronDensitySolver`s
- reinstates heuristics for `AutoPTR` step sizes (now prints a message explaining so)
- addresses a tolerance scaling question about how to set an integration tolerances for a transport distribution when multiplied with a Fermi window function by doing nothing to the caller's tolerance, since the integrated weight of the window function is close to unity. Previously the user had to set part of this tolerance, which we dealt with in v0.5 by having the user set only the overall tolerance for the solver
