### PR TITLE
v0.5.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AutoBZ"
 uuid = "00d1ae05-4f20-4598-b864-bbb2ed8900e6"
 authors = ["lxvm <lorenzo@vanmunoz.com> and contributors"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 AutoBZCore = "66bd3e16-1600-45cf-8f55-0b550710682b"

--- a/src/ElectronDensitySolver.jl
+++ b/src/ElectronDensitySolver.jl
@@ -59,8 +59,8 @@ function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz
     end |> fun |> x -> x*fermi(β, ω)
     inner_kws = _rescale_abstol(inv(V*nsyms(bz)); kws...)
     proto = post_k(solve(linprob, linalg), (fdom[1]+fdom[2])/2, p_k)
-    f = CommonSolveIntegralFunction(linprob, linalg, up_k, post_k, proto)
-    fprob = IntegralProblem(f, get_safe_fermi_function_limits(β, fdom...), p_k; inner_kws...)
+    f_k = CommonSolveIntegralFunction(linprob, linalg, up_k, post_k, proto)
+    fprob = IntegralProblem(f_k, get_safe_fermi_function_limits(β, fdom...), p_k; inner_kws...)
     linprob, rep =  linalg isa LinearSystemAlgorithm ? (LinearSystemProblem(A), UnknownRep()) :
                     linalg isa TraceInverseAlgorithm ? (TraceInverseProblem(A), TrivialRep()) :
                     throw(ArgumentError("$linalg is neither a LinearSystemAlgorithm nor TraceInverseAlgorithm"))
@@ -74,8 +74,8 @@ function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz
         return
     end
     post = (sol, k, h, p) -> sol.value
-    g = CommonSolveFourierIntegralFunction(fprob, falg, up, post, h, proto*μ)
-    prob = AutoBZProblem(rep, g, bz, p; kws...)
+    f = CommonSolveFourierIntegralFunction(fprob, falg, up, post, h, proto*μ)
+    prob = AutoBZProblem(rep, f, bz, p; kws...)
     return init(prob, _heuristic_bzalg(bzalg, Σ, h))
 end
 

--- a/src/ElectronDensitySolver.jl
+++ b/src/ElectronDensitySolver.jl
@@ -1,7 +1,8 @@
-function _DynamicalOccupiedGreensSolver(fun::F, Σ::AbstractSelfEnergy, fdom, falg, h::AbstractHamiltonianInterp, bz, bzalg, linalg; β, μ=zero(inv(oneunit(β))), bandwidth=one(μ), kws...) where {F}
+function _DynamicalOccupiedGreensSolver(fun::F, Σ::AbstractSelfEnergy, fdom, falg, h::AbstractHamiltonianInterp, bz, bzalg, linalg; β, μ=zero(inv(oneunit(β))), scale_inner=nothing, kws...) where {F}
     # TODO better estimate the bandwidth since the Fermi function is a semi-infinite window
+    bandwidth = oneunit(μ)
     V = abs(det(bz.B))
-    inner_kws = _rescale_abstol(inv(bandwidth); kws...)
+    inner_kws = _rescale_abstol(something(scale_inner, inv(bandwidth)); kws...)
     dos_prob = _GreensProblem(fun, Σ, h, bz, linalg; ω=(fdom[1]+fdom[2])/2, μ, inner_kws...)
     p = (; β, μ)
     proto = dos_prob.f.prototype * V * fermi(β, (fdom[1]+fdom[2])/2)
@@ -28,7 +29,7 @@ function update_density!(solver::AutoBZCore.IntegralSolver; β, μ=zero(inv(oneu
     return
 end
 
-function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz, bzalg, Σ::AbstractSelfEnergy, fdom, falg, linalg; β, μ=zero(inv(oneunit(β))), kws...) where {F}
+function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz, bzalg, Σ::AbstractSelfEnergy, fdom, falg, linalg; β, μ=zero(inv(oneunit(β))), scale_inner=nothing, kws...) where {F}
     V = abs(det(bz.B))
     k = period(h)
     hk = h(k)
@@ -57,7 +58,7 @@ function _DynamicalOccupiedGreensSolver(fun::F, h::AbstractHamiltonianInterp, bz
     else
         error("$sol is neither a LinearSystemSolution nor TraceInverseSolution")
     end |> fun |> x -> x*fermi(β, ω)
-    inner_kws = _rescale_abstol(inv(V*nsyms(bz)); kws...)
+    inner_kws = _rescale_abstol(something(scale_inner, inv(V*nsyms(bz))); kws...)
     proto = post_k(solve(linprob, linalg), (fdom[1]+fdom[2])/2, p_k)
     f_k = CommonSolveIntegralFunction(linprob, linalg, up_k, post_k, proto)
     fprob = IntegralProblem(f_k, get_safe_fermi_function_limits(β, fdom...), p_k; inner_kws...)
@@ -85,16 +86,16 @@ function update_density!(solver::AutoBZCore.AutoBZCache; β, μ=zero(inv(oneunit
 end
 
 """
-    ElectronDensitySolver(h, bz, bzalg, Σ, [fdom,] falg, [trinvalg=JLTrInv()]; β, μ=0, kws...)
-    ElectronDensitySolver(Σ, [fdom,] falg, h, bz, bzalg, [trinvalg=JLTrInv()]; β, μ=0, bandwidth=1, kws...)
+    ElectronDensitySolver(h, bz, bzalg, Σ, [fdom,] falg, [trinvalg=JLTrInv()]; β, μ=0, scale_inner=inv(abs(det(bz.B))*nsyms(bz)), kws...)
+    ElectronDensitySolver(Σ, [fdom,] falg, h, bz, bzalg, [trinvalg=JLTrInv()]; β, μ=0, scale_inner=inv(oneunit(μ)), kws...)
 
 A solver for the electron density.
 The two orderings of arguments correspond to orders of integration.
 (The outer integral appears first in the argument list.)
 Use `AutoBZ.update_density!(solver; β, μ=0)`.
 If `fdom` is not specified the default is `(AutoBZ.lb(Σ), AutoBZ.ub(Σ))`.
-The `bandwidth` keyword is used to rescale inner tolerances and should be estimated to
-reduce effort.
+The `scale_inner` keyword is used to rescale inner integration tolerances and can be
+estimated to reduce computational effort, although the default will be robust.
 `trinvalg` may be specified as an algorithm for the inverse trace calculation.
 
 Mathematically, this computes the electron density:

--- a/test/AuxKineticCoefficientSolver.jl
+++ b/test/AuxKineticCoefficientSolver.jl
@@ -6,7 +6,7 @@ for d in 1:3
     bz = load_bz(CubicSymIBZ(d))
     for h in [
         let h=coeffs2FourierHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), LAPACKEigen(); gauge=Wannier()); end,
-        let h=coeffs2HermitianHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Wannier()); end,
+        let h=coeffs2HermitianHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Hamiltonian()); end,
         # let h=coeffs2RealSymmetricHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Wannier()); end,
     ]
         η = 1.0

--- a/test/AuxTransportDistributionSolver.jl
+++ b/test/AuxTransportDistributionSolver.jl
@@ -5,7 +5,7 @@ for d in 1:3
     C = integer_lattice(d)
     bz = load_bz(CubicSymIBZ(d))
     for hv in [
-        let h=coeffs2FourierHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), LAPACKEigen(); gauge=Hamiltonian()); end,
+        let h=coeffs2FourierHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), LAPACKEigen(); gauge=Wannier()); end,
         let h=coeffs2HermitianHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Hamiltonian()); end,
         # let h=coeffs2RealSymmetricHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Hamiltonian()); end,
     ]

--- a/test/ElectronDensitySolver.jl
+++ b/test/ElectronDensitySolver.jl
@@ -8,7 +8,7 @@ for d in 1:3
     V = abs(det(bz.B))
     for h in [
         coeffs2FourierHamiltonian(C),
-        coeffs2HermitianHamiltonian(C),
+        coeffs2HermitianHamiltonian(C; gauge=Hamiltonian()),
         # coeffs2RealSymmetricHamiltonian(C),
     ]
         η = 1.0

--- a/test/KineticCoefficientSolver.jl
+++ b/test/KineticCoefficientSolver.jl
@@ -6,7 +6,7 @@ for d in 1:3
     bz = load_bz(CubicSymIBZ(d))
     for h in [
         let h=coeffs2FourierHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), LAPACKEigen(); gauge=Wannier()); end,
-        let h=coeffs2HermitianHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Wannier()); end,
+        let h=coeffs2HermitianHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Hamiltonian()); end,
         # let h=coeffs2RealSymmetricHamiltonian(C); GradientVelocityInterp(h, bz.A, EigenProblem(h(rand(d))), JLEigen(); gauge=Wannier()); end,
     ]
         η = 1.0


### PR DESCRIPTION
This pr fixes a bug when using the `Hamiltonian` gauge for `ElectronDensitySolver` and adds a `scale_inner` keyword to double integrals in order to have better control over tolerances for inner integrals