### PR TITLE
add pythtb band visualization example

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install documentation dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - name: Install dependencies
-        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'ENV["PYTHON"]=""; using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); using Conda; print(read(joinpath(dirname(pathof(Conda)), "..", "deps", "deps.jl")),String)); Conda.pip_interop(true); Conda.pip("install", "pythtb")'
+        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'ENV["PYTHON"]=""; using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("PyCall"); using Conda; print(read(joinpath(dirname(pathof(Conda)), "..", "deps", "deps.jl"),String)); Conda.pip_interop(true); Conda.pip("install", "pythtb")'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install documentation dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - name: Install dependencies
-        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'ENV["PYTHON"]=""; using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); using Conda; Conda.pip_interop(true); Conda.pip("install", "pythtb")'
+        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'ENV["PYTHON"]=""; using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); using Conda; print(read(joinpath(dirname(pathof(Conda)), "..", "deps", "deps.jl")),String)); Conda.pip_interop(true); Conda.pip("install", "pythtb")'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install documentation dependencies
         run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - name: Install dependencies
-        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: DISPLAY=:0 xvfb-run -s '-screen 0 1024x768x24' julia --project=docs/ -e 'ENV["PYTHON"]=""; using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); using Conda; Conda.pip_interop(true); Conda.pip("install", "pythtb")'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"

--- a/docs/src/pages/viz/band.md
+++ b/docs/src/pages/viz/band.md
@@ -7,9 +7,50 @@ visualize k-paths.
 
 ## Energy bands
 
-!!! note "In progress"
-    This will be added soon
+In the following example, we plot the band structure of graphene defined as a tight binding model in PythTB.
+This serves to reproduce the [PythTB homepage example](https://www.physics.rutgers.edu/pythtb/) using AutoBZ.jl and highlight the [`load_pythtb_data`](@ref) interface.
+
+```@example
+using PyCall
+py"""
+from pythtb import *
+
+# lattice vectors and orbital positions
+lat=[[1.0, 0.0], [0.5, np.sqrt(3.0)/2.0]]
+orb=[[1./3., 1./3.], [2./3., 2./3.]]
+
+# two-dimensional tight-binding model
+gra=tb_model(2, 2, lat, orb)
+
+# define hopping between orbitals
+gra.set_hop(-1.0, 0, 1, [ 0, 0])
+gra.set_hop(-1.0, 1, 0, [ 1, 0])
+gra.set_hop(-1.0, 1, 0, [ 0, 1])
+
+k=[[0.0, 0.0],[1./3., 2./3.],[0.5,0.5]]
+path=gra.k_path(k, 100)
+"""
+gra = py"gra"
+(k_vec,k_dist,k_node)=py"path"
+
+using AutoBZ
+h,bz = load_pythtb_data(gra)
+
+using LinearAlgebra
+hk = getproperty.(eigen.(h.(eachrow(k_vec))), :values)
+
+using GLMakie
+fig = Figure()
+ax = Axis(fig[1,1]; xticks = (k_node, ["Γ", "K", "M"]))
+series!(ax, k_dist, stack(hk))
+save("grapheneband.png", fig); nothing # hide
+```
+
+![Graphene band kpath](grapheneband.png)
 
 ## Band velocities
 
-To overlay band velocities on the k-ath 
+!!! note "In progress"
+    This will be added soon
+
+To overlay band velocities on the k-path

--- a/docs/src/pages/viz/bz.md
+++ b/docs/src/pages/viz/bz.md
@@ -77,7 +77,22 @@ save("tf_k.png", v); nothing # hide
 
 ## Conductivity
 
-To plot the conductivity contributions at each k-point, a frequency integral
-needs to be evaluated and AutoBZ.jl does not currently provide an API to
-evaluate that. Since this would require internals, we do not provide an example
-and instead request that you open a Github issue if you would like this feature.
+```@example viz
+Ω = 0.4
+solver = OpticalConductivitySolver(hv, bz, PTR(npt=50), Σ, QuadGKJL(); μ, β, Ω, abstol=1e-3, reltol=1e-3)
+ksolver = init(solver.f.prob, solver.f.alg; solver.f.kwargs...)
+
+kvals = map(Iterators.product(kpts, kpts, kpts[1:26])) do k
+    hvk = hv(k)
+    solver.f.update!(ksolver, k, hvk, solver.p)
+    sol = solve!(ksolver)
+    solver.f.postsolve(sol, k, hvk, solver.p)
+end
+kvals_density = real.(tr.(kvals)) ./ maximum(real.(tr.(kvals)))
+
+v = volume(kvals_density; algorithm=:iso, isovalue=1.0, isorange=0.5,
+colormap=cgrad([:teal, :teal],10))
+save("oc_k.png", v); nothing # hide
+```
+
+![optical conductivity BZ visualization](oc_k.png)

--- a/src/wannier90io.jl
+++ b/src/wannier90io.jl
@@ -37,7 +37,7 @@ end
 """
     load_interp(::Type{<:HamiltonianInterp}, seed;
         gauge=Wannier(), soc=nothing,
-        compact=:N, precision=Float64, droptol=eps(precision))
+        compact=:N, precision=Float64, droptol=eps(precision), herm=true)
 
 Load Hamiltonian coefficients from Wannier90 output `"seed_hr.dat"` into an
 [`AbstractHamiltonianInterp`](@ref) that interpolates `h` with unit period. The
@@ -56,6 +56,11 @@ coefficients under the given relative tolerance. Possible values of `compact` ar
 - `:L`: store the lower triangle of the coefficients
 - `:U`: store the upper triangle of the coefficients
 - `:S`: store the lower triangle of the symmetrized coefficients, `(c+c')/2`
+Additionally, the `herm` keyword specifies whether to check if the coefficients
+give a Hermitian matrix-valued Fourier series and if so it returns a special
+Hermitian series evaluator with optimizations for faster evaluation in `AutoBZ`
+workflows. To get a more user-friendly series for experimental usage, use
+`herm=false`.
 """
 function load_interp(::Type{<:HamiltonianInterp}, seed; precision=Float64, gauge=GaugeDefault(HamiltonianInterp), compact=:N, soc=nothing, droptol=eps(precision), herm=true)
     (; nkpt) = parse_wout(seed * ".wout", precision)
@@ -202,12 +207,17 @@ end
 """
     load_interp(::Type{<:GradientVelocityInterp}, seed, A;
         gauge=Wannier(), vcomp=Whole(), coord=Lattice(), soc=nothing,
-        precision=Float64, compact=:N, droptol=eps(precision))
+        precision=Float64, compact=:N, droptol=eps(precision), herm=true)
 
 Load coefficients for a Hamiltonian and its derivatives from Wannier90 output
 `"seed_hr.dat"` into a [`GradientVelocityInterp`](@ref) that interpolates `(h, v)`.
 Specify `vcomp` as [`Whole`](@ref), [`Intra`](@ref), or [`Inter`](@ref) to use
 certain transitions. Note these velocities are not gauge-covariant.
+Additionally, the `herm` keyword specifies whether to check if the coefficients
+give a Hermitian matrix-valued Fourier series and if so it returns a special
+Hermitian series evaluator with optimizations for faster evaluation in `AutoBZ`
+workflows. To get a more user-friendly series for experimental usage, use
+`herm=false`.
 """
 function load_interp(::Type{<:GradientVelocityInterp}, seed, A;
     precision=Float64, compact=:N, soc=nothing, droptol=eps(precision), herm=true,
@@ -222,12 +232,17 @@ end
 """
     load_interp(::Type{<:CovariantVelocityInterp}, seed, A;
         gauge=Wannier(), vcomp=whole(), coord=Lattice(), soc=nothing,
-        precision=Float64, compact=:N, droptol=eps(precision))
+        precision=Float64, compact=:N, droptol=eps(precision), herm=true)
 
 Load coefficients for a Hamiltonian and its derivatives from Wannier90 output
 `"seed_hr.dat"` and `"seed_r.dat"` into a [`CovariantVelocityInterp`](@ref) that
 interpolates `(h, v)`. Specify `vcomp` as [`Whole`](@ref), [`Intra`](@ref), or
 [`Inter`](@ref) to use certain transitions. These velocities are gauge-covariant.
+Additionally, the `herm` keyword specifies whether to check if the coefficients
+give a Hermitian matrix-valued Fourier series and if so it returns a special
+Hermitian series evaluator with optimizations for faster evaluation in `AutoBZ`
+workflows. To get a more user-friendly series for experimental usage, use
+`herm=false`.
 """
 function load_interp(::Type{<:CovariantVelocityInterp}, seed, A;
     precision=Float64, compact=:N, soc=nothing, droptol=eps(precision), herm=true,
@@ -243,12 +258,17 @@ end
 """
     load_interp(::Type{<:MassVelocityInterp}, seed, A;
         gauge=Wannier(), vcomp=Whole(), coord=Lattice(), soc=nothing,
-        precision=Float64, compact=:N, droptol=eps(precision))
+        precision=Float64, compact=:N, droptol=eps(precision), herm=true)
 
 Load coefficients for a Hamiltonian and its derivatives from Wannier90 output
 `"seed_hr.dat"` into a [`MassVelocityInterp`](@ref) that interpolates `(h, v, μ)`.
 Specify `vcomp` as [`Whole`](@ref), [`Intra`](@ref), or [`Inter`](@ref) to use
 certain transitions. Note these operators are not gauge-covariant.
+Additionally, the `herm` keyword specifies whether to check if the coefficients
+give a Hermitian matrix-valued Fourier series and if so it returns a special
+Hermitian series evaluator with optimizations for faster evaluation in `AutoBZ`
+workflows. To get a more user-friendly series for experimental usage, use
+`herm=false`.
 """
 function load_interp(::Type{<:MassVelocityInterp}, seed, A;
     precision=Float64, compact=:N, soc=nothing, droptol=eps(precision), herm=true,


### PR DESCRIPTION
This pr adds a band diagram visualization example that reproduces the homepage of [PythTB](https://www.physics.rutgers.edu/pythtb/)